### PR TITLE
Add AcroForm and outline tree to the output PDF

### DIFF
--- a/image/pdf_watermark_image.go
+++ b/image/pdf_watermark_image.go
@@ -84,6 +84,12 @@ func addWatermarkImage(inputPath string, outputPath string, watermarkPath string
 		_ = c.Draw(watermarkImg)
 	}
 
+	// Add reader outline tree to the creator.
+	c.SetOutlineTree(pdfReader.GetOutlineTree())
+
+	// Add reader AcroForm to the creator.
+	c.SetForms(pdfReader.AcroForm)
+
 	err = c.WriteToFile(outputPath)
 	return err
 }


### PR DESCRIPTION
Add outline tree and AcroForm to the output PDF of the image/pdf_watermark_image.go example.