### PR TITLE
Example highlight text

### DIFF
--- a/text/pdf_highlight_text.go
+++ b/text/pdf_highlight_text.go
@@ -1,7 +1,7 @@
 /*
- * Highlight text: Hightlight target texts in side the PDF file.
+ * Highlight text: Hightlight target texts inside the PDF file.
  *
- * Run as: go run pdf_text_locations.go file.pdf term
+ * Run as: go run pdf_highlight_text.go inputFile.pdf outputFile.pdf term
  */
 
 package main

--- a/text/pdf_highlight_text.go
+++ b/text/pdf_highlight_text.go
@@ -1,5 +1,5 @@
 /*
- * Highlight text: Hightlight target texts inside the PDF file.
+ * Highlight text: High light target texts inside the Pdf file.
  *
  * Run as: go run pdf_highlight_text.go inputFile.pdf outputFile.pdf term
  */
@@ -10,20 +10,22 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/unidoc/unipdf/v3/common/license"
 	"github.com/unidoc/unipdf/v3/creator"
 	"github.com/unidoc/unipdf/v3/extractor"
 	"github.com/unidoc/unipdf/v3/model"
 )
 
-func init() {
-	err := license.SetMeteredKey(`put your license key here`)
-	if err != nil {
-		panic(err)
-	}
-}
 func main() {
+	// Make sure to enter a valid license key.
+	// Otherwise the code will exit with a panic error.
+	// License keys are available via: https://unidoc.io
+	/*
+			license.SetLicenseKey(`
+		-----BEGIN UNIDOC LICENSE KEY-----
+		...key contents...
+		-----END UNIDOC LICENSE KEY-----
+		`)
+	*/
 	if len(os.Args) < 4 {
 		fmt.Printf("Usage: go run pdf_highlight_text.go <input.pdf> <output.pdf> <term> \n")
 		os.Exit(0)
@@ -32,14 +34,16 @@ func main() {
 	outputPath := os.Args[2]
 	term := os.Args[3]
 
-	err := hightlightWords(inputPath, outputPath, term)
+	err := highlightWords(inputPath, outputPath, term)
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("Successfully highlighted the word %s and created %s\n", term, outputPath)
 }
+
+// getBoundingBoxes returns the bounding boxes of all instances of search`term` in the Pdf file.
 func getBoundingBoxes(page *model.PdfPage, term string) ([]*model.PdfRectangle, error) {
-	boundingBox := []*model.PdfRectangle{}
+	boundingBoxes := []*model.PdfRectangle{}
 	ex, _ := extractor.New(page)
 	pageText, _, _, err := ex.ExtractPageText()
 	if err != nil {
@@ -61,11 +65,13 @@ func getBoundingBoxes(page *model.PdfPage, term string) ([]*model.PdfRectangle, 
 		if !ok {
 			return nil, fmt.Errorf("spanMarks.BBox has no bounding box. spanMarks=%s", spanMarks)
 		}
-		boundingBox = append(boundingBox, &bbox)
+		boundingBoxes = append(boundingBoxes, &bbox)
 	}
-	return boundingBox, nil
+	return boundingBoxes, nil
 
 }
+
+// indexAllSubstrings gets the begning indexes where `term` occures inside `text`.
 func indexAllSubstrings(text, term string) []int {
 	if len(term) == 0 {
 		return nil
@@ -81,7 +87,9 @@ func indexAllSubstrings(text, term string) []int {
 	}
 	return indexes
 }
-func hightlightWords(inputPath, outputPath, term string) error {
+
+// highlightWords highlights all occurrences of the search term.
+func highlightWords(inputPath, outputPath, term string) error {
 	reader, f, err := model.NewPdfReaderFromFile(inputPath, nil)
 	if err != nil {
 		panic(err)

--- a/text/pdf_highlight_text.go
+++ b/text/pdf_highlight_text.go
@@ -1,0 +1,135 @@
+/*
+ * Highlight text: Hightlight target texts in side the PDF file.
+ *
+ * Run as: go run pdf_text_locations.go file.pdf term
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/unidoc/unipdf/v3/common/license"
+	"github.com/unidoc/unipdf/v3/creator"
+	"github.com/unidoc/unipdf/v3/extractor"
+	"github.com/unidoc/unipdf/v3/model"
+)
+
+func init() {
+	err := license.SetMeteredKey(`put your license key here`)
+	if err != nil {
+		panic(err)
+	}
+}
+func main() {
+	if len(os.Args) < 4 {
+		fmt.Printf("Usage: go run pdf_highlight_text.go <input.pdf> <output.pdf> <term> \n")
+		os.Exit(0)
+	}
+	inputPath := os.Args[1]
+	outputPath := os.Args[2]
+	term := os.Args[3]
+
+	err := hightlightWords(inputPath, outputPath, term)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Successfully highlighted the word %s and created %s\n", term, outputPath)
+}
+func getBoundingBoxes(page *model.PdfPage, term string) ([]*model.PdfRectangle, error) {
+	boundingBox := []*model.PdfRectangle{}
+	ex, _ := extractor.New(page)
+	pageText, _, _, err := ex.ExtractPageText()
+	if err != nil {
+		return nil, err
+	}
+	textMarks := pageText.Marks()
+	text := pageText.Text()
+	indexes := indexAllSubstrings(text, term)
+	if len(indexes) == 0 {
+		return nil, nil
+	}
+	for _, start := range indexes {
+		end := start + len(term)
+		spanMarks, err := textMarks.RangeOffset(start, end)
+		if err != nil {
+			return nil, err
+		}
+		bbox, ok := spanMarks.BBox()
+		if !ok {
+			return nil, fmt.Errorf("spanMarks.BBox has no bounding box. spanMarks=%s", spanMarks)
+		}
+		boundingBox = append(boundingBox, &bbox)
+	}
+	return boundingBox, nil
+
+}
+func indexAllSubstrings(text, term string) []int {
+	if len(term) == 0 {
+		return nil
+	}
+	var indexes []int
+	for start := 0; start < len(text); {
+		i := strings.Index(text[start:], term)
+		if i < 0 {
+			return indexes
+		}
+		indexes = append(indexes, start+i)
+		start += i + len(term)
+	}
+	return indexes
+}
+func hightlightWords(inputPath, outputPath, term string) error {
+	reader, f, err := model.NewPdfReaderFromFile(inputPath, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	numPages, err := reader.GetNumPages()
+	if err != nil {
+		return err
+	}
+	cr := creator.New()
+	for n := 1; n <= numPages; n++ {
+		page, err := reader.GetPage(n)
+		if err != nil {
+			return err
+		}
+		bBoxes, err := getBoundingBoxes(page, term)
+		if err != nil {
+			return err
+		}
+
+		mediaBox, err := page.GetMediaBox()
+		if err != nil {
+			return err
+		}
+		if page.MediaBox == nil {
+			page.MediaBox = mediaBox
+		}
+
+		if err := cr.AddPage(page); err != nil {
+			return err
+		}
+		h := mediaBox.Ury
+		for _, bbox := range bBoxes {
+			rect := cr.NewRectangle(bbox.Llx, h-bbox.Lly, bbox.Urx-bbox.Llx, -(bbox.Ury - bbox.Lly))
+			rect.SetFillColor(creator.ColorRGBFromHex("#FFFF00"))
+			rect.SetBorderWidth(0)
+			rect.SetFillOpacity(0.5)
+			if err := cr.Draw(rect); err != nil {
+				return nil
+			}
+		}
+
+	}
+	cr.SetOutlineTree(reader.GetOutlineTree())
+
+	if err := cr.WriteToFile(outputPath); err != nil {
+		return fmt.Errorf("failed to write the output file %s", outputPath)
+	}
+	return nil
+}


### PR DESCRIPTION
This example demonstrates how to highlight a specific word in a pdf file.

E,g in the following sample output the word "Adobe" is highlighted.
![image](https://user-images.githubusercontent.com/24944408/146636164-2c2a074e-7168-49cd-8a43-99b8ae427965.png)
