### PR TITLE
[US-369] Example of creating PDF using lazy mode images

### DIFF
--- a/extract/pdf_extract_images.go
+++ b/extract/pdf_extract_images.go
@@ -103,7 +103,7 @@ func extractImagesToArchive(inputPath, outputPath string) error {
 			if err != nil {
 				return err
 			}
-			opt := jpeg.Options{Quality: 100}
+			opt := jpeg.Options{Quality: 80}
 			err = jpeg.Encode(imgf, gimg, &opt)
 			if err != nil {
 				return err

--- a/image/pdf_add_image_to_page.go
+++ b/image/pdf_add_image_to_page.go
@@ -98,8 +98,8 @@ func addImageToPdf(inputPath string, outputPath string, imagePath string, pageNu
 	encoder := core.NewDCTEncoder()
 	// The default quality is 75. There is not much difference in the image
 	// quality between 75 and 100 but the size difference when compressing the
-	// image stream is signficant.
-	// encoder.Quality = 100
+	// image stream is significant so setting quality to 100 is not recommended.
+	// encoder.Quality = 80
 	img.SetEncoder(encoder)
 
 	// Read the input pdf file.

--- a/image/pdf_images_to_pdf.go
+++ b/image/pdf_images_to_pdf.go
@@ -54,12 +54,13 @@ func imagesToPdf(inputPaths []string, outputPath string) error {
 			common.Log.Debug("Error loading image: %v", err)
 			return err
 		}
-		img.ScaleToWidth(612.0)
-
 		// Use page width of 612 points, and calculate the height proportionally based on the image.
 		// Standard PPI is 72 points per inch, thus a width of 8.5"
-		height := 612.0 * img.Height() / img.Width()
-		c.SetPageSize(creator.PageSize{612, height})
+		pageWidth := 612.0
+		img.ScaleToWidth(pageWidth)
+
+		pageHeight := pageWidth * img.Height() / img.Width()
+		c.SetPageSize(creator.PageSize{pageWidth, pageHeight})
 		c.NewPage()
 		img.SetPos(0, 0)
 		_ = c.Draw(img)

--- a/image/pdf_images_to_pdf_lazy.go
+++ b/image/pdf_images_to_pdf_lazy.go
@@ -1,0 +1,87 @@
+/*
+ * Add JPG images from given folder to a PDF file, one image per page using lazy mode.
+ *
+ * Run as: go run pdf_images_to_pdf.go output.pdf image_folder
+ */
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/unidoc/unipdf/v3/common"
+	"github.com/unidoc/unipdf/v3/common/license"
+	"github.com/unidoc/unipdf/v3/creator"
+)
+
+func init() {
+	// Make sure to load your metered License API key prior to using the library.
+	// If you need a key, you can sign up and create a free one at https://cloud.unidoc.io
+	err := license.SetMeteredKey(os.Getenv(`UNIDOC_LICENSE_API_KEY`))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Printf("Usage: go run pdf_images_to_pdf.go output.pdf image_folder\n")
+		os.Exit(1)
+	}
+
+	outputPath := os.Args[1]
+	inputPath := os.Args[2]
+
+	err := imageFolderToPdf(inputPath, outputPath)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Complete, see output file: %s\n", outputPath)
+}
+
+// Images to PDF.
+func imageFolderToPdf(inputPath string, outputPath string) error {
+	c := creator.New()
+
+	files, err := os.ReadDir(inputPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, imgPath := range files {
+		if !strings.HasSuffix(imgPath.Name(), ".jpg") {
+			continue
+		}
+		common.Log.Debug("Image: %s", imgPath)
+
+		path := path.Join(inputPath, imgPath.Name())
+
+		img, err := c.NewImageFromFile(path)
+		if err != nil {
+			common.Log.Debug("Error loading image: %v", err)
+			return err
+		}
+		// Set lazy mode for image allows to reduce memory consumption
+		// Lazy mode is helpful for creating PDF with a lot of images
+		img.SetLazy(true)
+
+		img.ScaleToWidth(612.0)
+
+		// Use page width of 612 points, and calculate the height proportionally based on the image.
+		// Standard PPI is 72 points per inch, thus a width of 8.5"
+		height := 612.0 * img.Height() / img.Width()
+		c.SetPageSize(creator.PageSize{612, height})
+		c.NewPage()
+		img.SetPos(0, 0)
+		_ = c.Draw(img)
+	}
+
+	err = c.WriteToFile(outputPath)
+	return err
+}

--- a/image/pdf_images_to_pdf_lazy.go
+++ b/image/pdf_images_to_pdf_lazy.go
@@ -71,12 +71,13 @@ func imageFolderToPdf(inputPath string, outputPath string) error {
 		// Lazy mode is helpful for creating PDF with a lot of images
 		img.SetLazy(true)
 
-		img.ScaleToWidth(612.0)
-
 		// Use page width of 612 points, and calculate the height proportionally based on the image.
 		// Standard PPI is 72 points per inch, thus a width of 8.5"
-		height := 612.0 * img.Height() / img.Width()
-		c.SetPageSize(creator.PageSize{612, height})
+		pageWidth := 612.0
+		img.ScaleToWidth(pageWidth)
+
+		pageHeight := pageWidth * img.Height() / img.Width()
+		c.SetPageSize(creator.PageSize{pageWidth, pageHeight})
 		c.NewPage()
 		img.SetPos(0, 0)
 		_ = c.Draw(img)

--- a/image/pdf_images_to_pdf_lazy.go
+++ b/image/pdf_images_to_pdf_lazy.go
@@ -1,7 +1,7 @@
 /*
  * Add JPG images from given folder to a PDF file, one image per page using lazy mode.
  *
- * Run as: go run pdf_images_to_pdf.go output.pdf image_folder
+ * Run as: go run pdf_images_to_pdf_lazy.go output.pdf image_folder
  */
 
 package main
@@ -29,7 +29,7 @@ func init() {
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Printf("Usage: go run pdf_images_to_pdf.go output.pdf image_folder\n")
+		fmt.Printf("Usage: go run pdf_images_to_pdf_lazy.go output.pdf image_folder\n")
 		os.Exit(1)
 	}
 

--- a/jbig2/jbig2_decompress.go
+++ b/jbig2/jbig2_decompress.go
@@ -64,7 +64,7 @@ func main() {
 		}
 		defer imgFile.Close()
 
-		err = jpeg.Encode(imgFile, img, &jpeg.Options{Quality: 100})
+		err = jpeg.Encode(imgFile, img, &jpeg.Options{Quality: 80})
 		if err != nil {
 			log.Fatalf("Error: %v\n", err)
 		}

--- a/jbig2/jbig2_decompress_with_globals.go
+++ b/jbig2/jbig2_decompress_with_globals.go
@@ -96,7 +96,7 @@ func main() {
 		}
 		defer imgFile.Close()
 
-		err = jpeg.Encode(imgFile, img, &jpeg.Options{Quality: 100})
+		err = jpeg.Encode(imgFile, img, &jpeg.Options{Quality: 80})
 		if err != nil {
 			log.Fatalf("Error: %v\n", err)
 		}


### PR DESCRIPTION
https://unidoc.atlassian.net/browse/US-369

The PR includes two changes: 
- New example of creating PDF using lazy mode images
- JPEG quality throughout examples is set to 75-80 since 100 makes the size a lot larger without much improvement of image quality. 