### PR TITLE
[US-443] File attachment annotation example

### DIFF
--- a/annotations/README.md
+++ b/annotations/README.md
@@ -6,15 +6,18 @@ document contents, without changing the original document contents.
 Support for creating annotations in UniPDF is through the unipdf/annotator package.
 The annotator package creates the Annotation object and also an appearance stream, which is required to make
 the annotation look the same in all viewers.
-UniPDF's model package has support for all types of PDF annotations, whereas the annotator currently supports Square,
-Circle, Line annotations.  Support for more annotation types will be added over time.  If you need support for an
-unsupported annotation, please create an issue in this repository.
 
-The examples in this folder illustrate a few capabilities for creating ellipse, lines, rectangles.
+UniPDF's model package has support for all types of PDF annotations, whereas the annotator currently supports Square,
+Circle, Ellipse, Ink, Line, and File attachment annotations.  Support for more annotation types will be added over time.  
+
+If you need support for an unsupported annotation, please create an issue in this repository.
+
+The examples in this folder illustrate a few capabilities for creating ellipse, file attachment, ink, lines, rectangles, and text annotation.
 
 ## Examples
 
 - [pdf_annotate_add_ellipse.go](pdf_annotate_add_ellipse.go) adds a circle/ellipse annotation to a specified location on a page.
+- [pdf_annotate_add_file.go](pdf_annotate_add_file.go) adds a file attachment annotation placed in certain position in a page.
 - [pdf_annotate_add_ink.go](pdf_annotate_add_ink.go) adds an ink annotation to a specified location on a page.
 - [pdf_annotate_add_line.go](pdf_annotate_add_line.go) adds a line with arrowhead between two specified points on a page.
 - [pdf_annotate_add_rectangle.go](pdf_annotate_add_rectangle.go) adds a rectangle annotation to a specified location on a page.

--- a/annotations/pdf_annotate_add_file.go
+++ b/annotations/pdf_annotate_add_file.go
@@ -1,0 +1,126 @@
+/*
+ * Annotate/mark up pages of a PDF file.
+ * Adds a file attachment annotation placed in certain position in a page.
+ *
+ * Run as: go run pdf_annotate_add_file.go input.pdf output.pdf file_to_be_attached
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/unidoc/unipdf/v3/annotator"
+	"github.com/unidoc/unipdf/v3/common/license"
+	"github.com/unidoc/unipdf/v3/model"
+)
+
+func init() {
+	// Make sure to load your metered License API key prior to using the library.
+	// If you need a key, you can sign up and create a free one at https://cloud.unidoc.io
+	err := license.SetMeteredKey(os.Getenv(`UNIDOC_LICENSE_API_KEY`))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	if len(os.Args) < 4 {
+		fmt.Printf("go run pdf_annotate_add_file.go input.pdf output.pdf file_to_be_attached\n")
+		os.Exit(1)
+	}
+
+	inputPath := os.Args[1]
+	outputPath := os.Args[2]
+	attachmentPath := os.Args[3]
+
+	err := annotatePdfAddFile(inputPath, outputPath, attachmentPath)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Complete, see output file: %s\n", outputPath)
+}
+
+func annotatePdfAddFile(inputPath string, outputPath string, attachmentPath string) error {
+	// Read the input pdf file.
+	f, err := os.Open(inputPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	pdfReader, err := model.NewPdfReader(f)
+	if err != nil {
+		return err
+	}
+
+	page, err := pdfReader.GetPage(1)
+	if err != nil {
+		return err
+	}
+
+	// Instantiate embedded file object from existing file path.
+	emFile, err := model.NewEmbeddedFile(attachmentPath)
+	if err != nil {
+		return err
+	}
+
+	// Overwrite attachment name.
+	emFile.Name = "dummy.xml"
+	emFile.Description = "Sample Attachment"
+	emFile.Relationship = model.RelationshipData
+
+	creationTime := time.Now()
+
+	// Get the page media box.
+	box, err := page.GetMediaBox()
+	if err != nil {
+		return err
+	}
+
+	// Create a file attachment annotation definition.
+	fileAnnotDef := annotator.FileAnnotationDef{
+		// Position of the pin image.
+		X: box.Urx - 20,
+		Y: box.Ury - 20,
+
+		// Size of the pin image.
+		Width:  10,
+		Height: 15,
+
+		// Color of the pin image.
+		Color: model.NewPdfColorDeviceRGB(1.0, 0, 0),
+
+		EmbeddedFile: emFile,
+		Description:  emFile.Description,
+		IconName:     "Paperclip",
+		CreationDate: &creationTime,
+	}
+
+	// Create a file attachment annotation.
+	fileAnnot, err := annotator.CreateFileAttachmentAnnotation(fileAnnotDef)
+	if err != nil {
+		return err
+	}
+
+	// Add annotation to a page.
+	page.AddAnnotation(fileAnnot)
+
+	// Generate a PdfWriter instance from existing PdfReader.
+	pdfWriter, err := pdfReader.ToWriter(nil)
+	if err != nil {
+		return err
+	}
+
+	// Write to file.
+	err = pdfWriter.WriteToFile(outputPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/unidoc/globalsign-dss v0.0.0-20220330092912-b69d85b63736
 	github.com/unidoc/pkcs7 v0.2.0
 	github.com/unidoc/unichart v0.3.0
-	github.com/unidoc/unipdf/v3 v3.58.0
+	github.com/unidoc/unipdf/v3 v3.59.0
 	github.com/wcharczuk/go-chart/v2 v2.1.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/image v0.15.0
@@ -32,7 +32,6 @@ require (
 	github.com/adrg/sysfont v0.1.2 // indirect
 	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a h1:RLtvUhe4DsUDl6
 github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a/go.mod h1:j+qMWZVpZFTvDey3zxUkSgPJZEX33tDgU/QIA0IzCUw=
 github.com/unidoc/unichart v0.3.0 h1:VX1j5yzhjrR3f2flC03Yat6/WF3h7Z+DLEvJLoTGhoc=
 github.com/unidoc/unichart v0.3.0/go.mod h1:8JnLNKSOl8yQt1jXewNgYFHhFm5M6/ZiaydncFDpakA=
-github.com/unidoc/unipdf/v3 v3.58.0 h1:c2yWEw1FLxwoVCjcuUTeOAQn/HIHsh+zq+wlVFGwgKc=
-github.com/unidoc/unipdf/v3 v3.58.0/go.mod h1:HEGsUAyg0cI46ofB2D4b6FzBXzVM2P1mHvQ5R+HxONs=
+github.com/unidoc/unipdf/v3 v3.59.0 h1:Kgo1+s/KYQyz7YLvBTrH9vu0E7Q0hPklm8KmVBGPACQ=
+github.com/unidoc/unipdf/v3 v3.59.0/go.mod h1:HEGsUAyg0cI46ofB2D4b6FzBXzVM2P1mHvQ5R+HxONs=
 github.com/unidoc/unitype v0.4.0 h1:/TMZ3wgwfWWX64mU5x2O9no9UmoBqYCB089LYYqHyQQ=
 github.com/unidoc/unitype v0.4.0/go.mod h1:HV5zuUeqMKA4QgYQq3KDlJY/P96XF90BQB+6czK6LVA=
 github.com/wcharczuk/go-chart/v2 v2.1.0 h1:tY2slqVQ6bN+yHSnDYwZebLQFkphK4WNrVwnt7CJZ2I=


### PR DESCRIPTION
Code example for adding file attachment annotation that introduced in UniPDF v3.59.0