### PR TITLE
[US-924] Remove Mentions of Perpetual License

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ functionality that requires CGO and external dependencies. Those examples are cl
 ## License codes
 UniPDF requires license codes to operate, there are two options:
 - Metered License API keys: Free ones can be obtained at https://cloud.unidoc.io
-- Offline Perpetual codes: Can be purchased at https://unidoc.io/pricing
+- Offline codes: Can be purchased at https://unidoc.io/pricing
 
 Most of the examples demonstrate loading the Metered License API keys through an environment
 variable `UNIDOC_LICENSE_API_KEY`.
 
-Examples for Offline Perpetual License Key loading can be found in the license subdirectory.
+Examples for Offline License Key loading can be found in the license subdirectory.
 
 ### Build all examples
 

--- a/license/unipdf_license_loading_offline.go
+++ b/license/unipdf_license_loading_offline.go
@@ -1,6 +1,6 @@
 /*
  * unipdf_license_loading_offline.go:
- * Illustrates how to load an offline (perpetual) license key.
+ * Illustrates how to load an offline license key.
  * Offline keys can be purchased at https://www.unidoc.io
  *
  * Run as: go run unipdf_license_loading_offline.go
@@ -14,7 +14,7 @@ import (
 	"github.com/unidoc/unipdf/v3/common/license"
 )
 
-// Example of an offline perpetual license key.
+// Example of an offline license key.
 const offlineLicenseKey = `
 -----BEGIN UNIDOC LICENSE KEY-----
 contents here.


### PR DESCRIPTION
This PR removes the mention of Offline License and Perpetual License from the example repo. 
I used simple search to find these mentions.
https://unidoc.atlassian.net/browse/US-924