### PR TITLE
Release v3.30.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/trimmer-io/go-xmp v1.0.0
 	github.com/unidoc/globalsign-dss v0.0.0-20220330092912-b69d85b63736
 	github.com/unidoc/pkcs7 v0.2.0
-	github.com/unidoc/unichart v0.3.0
-	github.com/unidoc/unipdf/v3 v3.67.0
+	github.com/unidoc/unichart v0.4.0
+	github.com/unidoc/unipdf/v3 v3.68.0
 	golang.org/x/crypto v0.33.0
 	golang.org/x/image v0.24.0
 	golang.org/x/text v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,12 @@ github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a h1:RLtvUhe4DsUDl6
 github.com/unidoc/timestamp v0.0.0-20200412005513-91597fd3793a/go.mod h1:j+qMWZVpZFTvDey3zxUkSgPJZEX33tDgU/QIA0IzCUw=
 github.com/unidoc/unichart v0.3.0 h1:VX1j5yzhjrR3f2flC03Yat6/WF3h7Z+DLEvJLoTGhoc=
 github.com/unidoc/unichart v0.3.0/go.mod h1:8JnLNKSOl8yQt1jXewNgYFHhFm5M6/ZiaydncFDpakA=
+github.com/unidoc/unichart v0.4.0 h1:uXk9ZjbqzKb8Lt2Qv2oM9D2ftNRXvezPevgxQhsTQys=
+github.com/unidoc/unichart v0.4.0/go.mod h1:9QsE8RbS0fE7ndHNroeCEFkRPqqk47Qsoj6QSAtcwN0=
 github.com/unidoc/unipdf/v3 v3.67.0 h1:t1ZkNX5iFhGLDPN/68MQOPAq4iXK4tTi7ePpSUBWkdo=
 github.com/unidoc/unipdf/v3 v3.67.0/go.mod h1:S5BLo/oBIxAaQtB0Lw3wFqPFOY3U1oU+NISbjX9xEBA=
+github.com/unidoc/unipdf/v3 v3.68.0 h1:AM1wKukv75hvCtTbiPb3HSIdHS5RbmR6aYTCE0jiO+A=
+github.com/unidoc/unipdf/v3 v3.68.0/go.mod h1:4mQ4E8niuY+30TGxT1e/8aVoSk/nn0yCKfi+kYw98+I=
 github.com/unidoc/unitype v0.5.1 h1:UwTX15K6bktwKocWVvLoijIeu4JAVEAIeFqMOjvxqQs=
 github.com/unidoc/unitype v0.5.1/go.mod h1:3dxbRL+f1otNqFQIRHho8fxdg3CcUKrqS8w1SXTsqcI=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=


### PR DESCRIPTION
Update unipdf version to v3.68.0

This pull request includes updates to the dependencies in the `go.mod` file. The changes involve upgrading two libraries to their latest versions.

Dependency updates:

* `github.com/unidoc/unichart` upgraded from version `v0.3.0` to `v0.4.0`
* `github.com/unidoc/unipdf/v3` upgraded from version `v3.67.0` to `v3.68.0`