### PR TITLE
[US-956] Replaces references to `Paragraph` with `StyledParagraph`

### DIFF
--- a/accessibility/pdf_set_language_identifier.go
+++ b/accessibility/pdf_set_language_identifier.go
@@ -51,8 +51,9 @@ func main() {
 
 	str.AddKDict(docK)
 
-	// Create a new paragraph.
-	p := c.NewParagraph("Hello World")
+	// Create a new styled paragraph.
+	p := c.NewStyledParagraph()
+	p.SetText("Hello World")
 	p.SetPos(100, 100)
 
 	// Set marked content identifier for the paragraph.

--- a/arabic-text/pdf_write_arabic.go
+++ b/arabic-text/pdf_write_arabic.go
@@ -49,7 +49,8 @@ func main() {
 		panic(err)
 	}
 
-	par := c.NewParagraph(textArabicShaped)
+	par := c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentCenter)
@@ -71,7 +72,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetTextAlignment(creator.TextAlignmentRight)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
@@ -81,7 +83,8 @@ func main() {
 		fmt.Println(err)
 	}
 
-	par = c.NewParagraph("This is a pretty simple paragraph")
+	par = c.NewStyledParagraph()
+	par.SetText("This is a pretty simple paragraph")
 	par.SetTextAlignment(creator.TextAlignmentRight)
 	par.SetMargins(marginLeft, marginRight, marginTop, marginBottom)
 	err = c.Draw(par)
@@ -89,7 +92,8 @@ func main() {
 		fmt.Println(err)
 	}
 
-	par = c.NewParagraph("LTR: Looks, we adding more simple paragraph here lets try to write it, how it looks like. Is it good? How about we add more word here")
+	par = c.NewStyledParagraph()
+	par.SetText("LTR: Looks, we adding more simple paragraph here lets try to write it, how it looks like. Is it good? How about we add more word here")
 	par.SetTextAlignment(creator.TextAlignmentRight)
 	par.SetMargins(marginLeft, marginRight, marginTop, marginBottom)
 	err = c.Draw(par)
@@ -97,7 +101,8 @@ func main() {
 		fmt.Println(err)
 	}
 
-	par = c.NewParagraph("RTL: Looks, we adding more simple paragraph here lets try to write it, how it looks like. Is it good? How about we add more word here")
+	par = c.NewStyledParagraph()
+	par.SetText("RTL: Looks, we adding more simple paragraph here lets try to write it, how it looks like. Is it good? How about we add more word here")
 	par.SetTextAlignment(creator.TextAlignmentRight)
 	par.SetMargins(marginLeft, marginRight, marginTop, marginBottom)
 	err = c.Draw(par)
@@ -109,7 +114,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -119,7 +125,8 @@ func main() {
 		fmt.Println(err)
 	}
 
-	par = c.NewParagraph("Looks, we adding more paragraph here")
+	par = c.NewStyledParagraph()
+	par.SetText("Looks, we adding more paragraph here")
 	par.SetTextAlignment(creator.TextAlignmentRight)
 	par.SetMargins(marginLeft, marginRight, marginTop, marginBottom)
 	err = c.Draw(par)
@@ -131,7 +138,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -145,7 +153,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -155,7 +164,8 @@ func main() {
 		fmt.Println(err)
 	}
 
-	par = c.NewParagraph("How about we add more paragraphs?")
+	par = c.NewStyledParagraph()
+	par.SetText("How about we add more paragraphs?")
 	par.SetTextAlignment(creator.TextAlignmentRight)
 	par.SetMargins(marginLeft, marginRight, marginTop, marginBottom)
 	err = c.Draw(par)
@@ -164,7 +174,8 @@ func main() {
 	}
 
 	textMixed, err := textshaping.ArabicShape("The names of these states in Arabic are مصر, البحري and الكويت respectively. Add another word here, should be in new line.")
-	par = c.NewParagraph(textMixed)
+	par = c.NewStyledParagraph()
+	par.SetText(textMixed)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetMargins(marginLeft, marginRight, marginTop, marginBottom)
@@ -178,7 +189,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -193,7 +205,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -208,7 +221,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -223,7 +237,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -238,7 +253,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -253,7 +269,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -268,7 +285,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)
@@ -283,7 +301,8 @@ func main() {
 		panic(err)
 	}
 
-	par = c.NewParagraph(textArabicShaped)
+	par = c.NewStyledParagraph()
+	par.SetText(textArabicShaped)
 	par.SetFont(arabicFont)
 	par.SetFontSize(fontSize)
 	par.SetTextAlignment(creator.TextAlignmentRight)

--- a/barcode/pdf_add_barcode.go
+++ b/barcode/pdf_add_barcode.go
@@ -162,7 +162,8 @@ func addBarcodeToPdf(inputPath string, outputPath string, codeStr string, pageNu
 			_ = c.Draw(img)
 
 			// Add the code below.
-			p := c.NewParagraph(codeStr)
+			p := c.NewStyledParagraph()
+			p.SetText(codeStr)
 			p.SetWidth(width)
 			p.SetTextAlignment(creator.TextAlignmentCenter)
 			p.SetPos(xPos, yPos+img.Height())

--- a/extract/reconstruct_text.go
+++ b/extract/reconstruct_text.go
@@ -86,12 +86,13 @@ func reconstruct(pdfPath string) error {
 			}
 			fmt.Printf("%s\n", tm.Text)
 			// Reconstruct by drawing each glyph from textmarks with the creator package.
-			para := c.NewParagraph(tm.Original)
+			para := c.NewStyledParagraph()
+			para.SetText(tm.Original)
 			para.SetFont(tm.Font)
 			para.SetFontSize(tm.FontSize)
 			r, g, b, _ := tm.StrokeColor.RGBA()
 			rf, gf, bf := float64(r)/0xffff, float64(g)/0xffff, float64(b)/0xffff
-			para.SetColor(creator.ColorRGBFromArithmetic(rf, gf, bf))
+			para.SetFontColor(creator.ColorRGBFromArithmetic(rf, gf, bf))
 			// Convert to PDF coordinate system.
 			yPos := c.Context().PageHeight - (tm.BBox.Lly + tm.BBox.Height())
 			para.SetPos(tm.BBox.Llx, yPos) // Upper left corner.

--- a/extract/reconstruct_words.go
+++ b/extract/reconstruct_words.go
@@ -104,12 +104,13 @@ func reconstruct(pdfPath string) error {
 			}
 			fmt.Printf("%s\n", tm.Text)
 			// Reconstruct by drawing each glyph from textmarks with the creator package.
-			para := c.NewParagraph(tm.Original)
+			para := c.NewStyledParagraph()
+			para.SetText(tm.Original)
 			para.SetFont(tm.Font)
 			para.SetFontSize(tm.FontSize)
 			r, g, b, _ := tm.StrokeColor.RGBA()
 			rf, gf, bf := float64(r)/0xffff, float64(g)/0xffff, float64(b)/0xffff
-			para.SetColor(creator.ColorRGBFromArithmetic(rf, gf, bf))
+			para.SetFontColor(creator.ColorRGBFromArithmetic(rf, gf, bf))
 			// Convert to PDF coordinate system.
 			yPos := c.Context().PageHeight - (tm.BBox.Lly + tm.BBox.Height())
 			para.SetPos(tm.BBox.Llx, yPos) // Upper left corner.

--- a/forms/pdf_form_action.go
+++ b/forms/pdf_form_action.go
@@ -64,7 +64,8 @@ func main() {
 
 		y := pageHeight - fdef.Rect[1]
 
-		p := c.NewParagraph(fdef.Label)
+		p := c.NewStyledParagraph()
+		p.SetText(fdef.Label)
 		p.SetPos(fdef.Rect[0]-80, y-10)
 		err = c.Draw(p)
 		if err != nil {

--- a/forms/pdf_form_with_text_color.go
+++ b/forms/pdf_form_with_text_color.go
@@ -68,7 +68,8 @@ func main() {
 
 		y := pageHeight - fdef.Rect[1]
 
-		p := c.NewParagraph(fdef.Label)
+		p := c.NewStyledParagraph()
+		p.SetText(fdef.Label)
 		p.SetPos(fdef.Rect[0]-80, y-10)
 		err = c.Draw(p)
 		if err != nil {

--- a/report/pdf_custom_toc.go
+++ b/report/pdf_custom_toc.go
@@ -33,7 +33,8 @@ func main() {
 	c.AddTOC = true
 	c.CustomTOC = true
 	c.CreateTableOfContents(func(toc *creator.TOC) error {
-		tocTitle := c.NewParagraph("Table of Contents")
+		tocTitle := c.NewStyledParagraph()
+		tocTitle.SetText("Table of Contents")
 		tocTitle.SetFontSize(20)
 		tocTitle.SetMargins(0, 0, 0, 20)
 

--- a/report/pdf_report.go
+++ b/report/pdf_report.go
@@ -96,19 +96,21 @@ func RunPdfReport(outputPath string) error {
 	// Draw footer on each page.
 	c.DrawFooter(func(block *creator.Block, args creator.FooterFunctionArgs) {
 		// Draw the on a block for each page.
-		p := c.NewParagraph("unidoc.io")
+		p := c.NewStyledParagraph()
+		p.SetText("unidoc.io")
 		p.SetFont(robotoFontRegular)
 		p.SetFontSize(8)
 		p.SetPos(50, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 
 		strPage := fmt.Sprintf("Page %d of %d", args.PageNum, args.TotalPages)
-		p = c.NewParagraph(strPage)
+		p = c.NewStyledParagraph()
+		p.SetText(strPage)
 		p.SetFont(robotoFontRegular)
 		p.SetFontSize(8)
 		p.SetPos(300, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 	})
 
@@ -125,28 +127,31 @@ func DoFirstPage(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model
 	helvetica, _ := model.NewStandard14Font("Helvetica")
 	helveticaBold, _ := model.NewStandard14Font("Helvetica-Bold")
 
-	p := c.NewParagraph("UniDoc")
+	p := c.NewStyledParagraph()
+	p.SetText("UniDoc")
 	p.SetFont(helvetica)
 	p.SetFontSize(48)
 	p.SetMargins(85, 0, 150, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 
-	p = c.NewParagraph("Example Report")
+	p = c.NewStyledParagraph()
+	p.SetText("Example Report")
 	p.SetFont(helveticaBold)
 	p.SetFontSize(30)
 	p.SetMargins(85, 0, 0, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(45, 148, 215))
+	p.SetFontColor(creator.ColorRGBFrom8bit(45, 148, 215))
 	c.Draw(p)
 
 	t := time.Now().UTC()
 	dateStr := t.Format("1 Jan, 2006 15:04")
 
-	p = c.NewParagraph(dateStr)
+	p = c.NewStyledParagraph()
+	p.SetText(dateStr)
 	p.SetFont(helveticaBold)
 	p.SetFontSize(12)
 	p.SetMargins(90, 0, 5, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 }
 
@@ -154,14 +159,17 @@ func DoFirstPage(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model
 func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model.PdfFont) {
 	ch := c.NewChapter("Document control")
 	ch.SetMargins(0, 0, 40, 0)
-	ch.GetHeading().SetFont(fontRegular)
-	ch.GetHeading().SetFontSize(18)
-	ch.GetHeading().SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
+
+	heading := ch.GetHeading()
+	heading.SetFont(fontRegular)
+	heading.SetFontSize(18)
+	heading.SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
 
 	sc := ch.NewSubchapter("Issuer details")
-	sc.GetHeading().SetFont(fontRegular)
-	sc.GetHeading().SetFontSize(18)
-	sc.GetHeading().SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
+	heading = sc.GetHeading()
+	heading.SetFont(fontRegular)
+	heading.SetFontSize(18)
+	heading.SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
 
 	issuerTable := c.NewTable(2)
 	issuerTable.SetMargins(0, 0, 30, 0)
@@ -169,87 +177,107 @@ func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	pColor := creator.ColorRGBFrom8bit(72, 86, 95)
 	bgColor := creator.ColorRGBFrom8bit(56, 68, 67)
 
-	p := c.NewParagraph("Issuer")
+	p := c.NewStyledParagraph()
+	p.SetText("Issuer")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell := issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("UniDoc")
+	p = c.NewStyledParagraph()
+	p.SetText("UniDoc")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Address")
+	p = c.NewStyledParagraph()
+	p.SetText("Address")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Klapparstig 16, 101 Reykjavik, Iceland")
+	p = c.NewStyledParagraph()
+	p.SetText("Klapparstig 16, 101 Reykjavik, Iceland")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Email")
+	p = c.NewStyledParagraph()
+	p.SetText("Email")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBackgroundColor(bgColor)
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("sales@unidoc.io")
+	p = c.NewStyledParagraph()
+	p.SetText("sales@unidoc.io")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Web")
+	p = c.NewStyledParagraph()
+	p.SetText("Web")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("unidoc.io")
+	p = c.NewStyledParagraph()
+	p.SetText("unidoc.io")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Author")
+	p = c.NewStyledParagraph()
+	p.SetText("Author")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("UniDoc report generator")
+	p = c.NewStyledParagraph()
+	p.SetText("UniDoc report generator")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
@@ -259,19 +287,23 @@ func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	// 1.2 - Document history
 	sc = ch.NewSubchapter("Document History")
 	sc.SetMargins(0, 0, 5, 0)
-	sc.GetHeading().SetFont(fontRegular)
-	sc.GetHeading().SetFontSize(18)
-	sc.GetHeading().SetFontColor(pColor)
+
+	heading = sc.GetHeading()
+	heading.SetFont(fontRegular)
+	heading.SetFontSize(18)
+	heading.SetFontColor(pColor)
 
 	histTable := c.NewTable(3)
 	histTable.SetMargins(0, 0, 30, 50)
 
 	histCols := []string{"Date Issued", "UniDoc Version", "Type/Change"}
 	for _, histCol := range histCols {
-		p = c.NewParagraph(histCol)
+		p = c.NewStyledParagraph()
+		p.SetText(histCol)
 		p.SetFont(fontBold)
 		p.SetFontSize(10)
-		p.SetColor(creator.ColorWhite)
+		p.SetFontColor(creator.ColorWhite)
+
 		cell = histTable.NewCell()
 		cell.SetBackgroundColor(bgColor)
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
@@ -284,10 +316,12 @@ func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 
 	histVals := []string{dateStr, common.Version, "First issue"}
 	for _, histVal := range histVals {
-		p = c.NewParagraph(histVal)
+		p = c.NewStyledParagraph()
+		p.SetText(histVal)
 		p.SetFont(fontRegular)
 		p.SetFontSize(10)
-		p.SetColor(pColor)
+		p.SetFontColor(pColor)
+
 		cell = histTable.NewCell()
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 		cell.SetHorizontalAlignment(creator.CellHorizontalAlignmentCenter)
@@ -321,30 +355,35 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 
 	bgColor := creator.ColorRGBFrom8bit(56, 68, 67)
 
-	ch.GetHeading().SetFont(chapterFont)
-	ch.GetHeading().SetFontSize(chapterFontSize)
-	ch.GetHeading().SetFontColor(chapterFontColor)
+	heading := ch.GetHeading()
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
 
-	p := c.NewParagraph("This chapter demonstrates a few of the features of UniDoc that can be used for report generation.")
+	p := c.NewStyledParagraph()
+	p.SetText("This chapter demonstrates a few of the features of UniDoc that can be used for report generation.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	ch.Add(p)
 
 	// Paragraphs.
 	sc := ch.NewSubchapter("Paragraphs")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Paragraphs are used to represent text, as little as a single character, a word or " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Paragraphs are used to represent text, as little as a single character, a word or " +
 		"multiple words forming multiple sentences. UniDoc handles automatically wrapping those across lines and pages, making " +
 		"it relatively easy to work with. They can also be left, center, right aligned or justified as illustrated below:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
@@ -357,10 +396,11 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	alignments := []creator.TextAlignment{creator.TextAlignmentLeft, creator.TextAlignmentCenter,
 		creator.TextAlignmentRight, creator.TextAlignmentJustify}
 	for j := 0; j < 4; j++ {
-		p = c.NewParagraph(loremTxt)
+		p = c.NewStyledParagraph()
+		p.SetText(loremTxt)
 		p.SetFont(normalFont)
 		p.SetFontSize(normalFontSize)
-		p.SetColor(normalFontColor)
+		p.SetFontColor(normalFontColor)
 		p.SetMargins(20, 0, 10, 10)
 		p.SetTextAlignment(alignments[j%4])
 
@@ -374,10 +414,12 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	// Column headers:
 	tableCols := []string{"Priority", "Items fulfilled / available"}
 	for _, tableCol := range tableCols {
-		p = c.NewParagraph(tableCol)
+		p = c.NewStyledParagraph()
+		p.SetText(tableCol)
 		p.SetFont(fontBold)
 		p.SetFontSize(10)
-		p.SetColor(creator.ColorWhite)
+		p.SetFontColor(creator.ColorWhite)
+
 		cell := priTable.NewCell()
 		cell.SetBackgroundColor(bgColor)
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
@@ -390,10 +432,12 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	}
 	for _, lineItems := range items {
 		for _, item := range lineItems {
-			p = c.NewParagraph(item)
+			p = c.NewStyledParagraph()
+			p.SetText(item)
 			p.SetFont(fontBold)
 			p.SetFontSize(10)
-			p.SetColor(creator.ColorWhite)
+			p.SetFontColor(creator.ColorWhite)
+
 			cell := priTable.NewCell()
 			cell.SetBackgroundColor(bgColor)
 			cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
@@ -403,15 +447,18 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(priTable)
 
 	sc = ch.NewSubchapter("Images")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Images can be loaded from multiple file formats, example from a PNG image:")
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Images can be loaded from multiple file formats, example from a PNG image:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 5)
 	sc.Add(p)
 
@@ -424,15 +471,18 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(img)
 
 	sc = ch.NewSubchapter("QR Codes / Barcodes")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Example of a QR code generated with package github.com/boombuler/barcode:")
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Example of a QR code generated with package github.com/boombuler/barcode:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 5)
 	sc.Add(p)
 
@@ -446,16 +496,19 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(img)
 
 	sc = ch.NewSubchapter("Graphing / Charts")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Graphs can be generated via packages such as github.com/unidoc/unichart as illustrated " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Graphs can be generated via packages such as github.com/unidoc/unichart as illustrated " +
 		"in the following plot:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
@@ -473,12 +526,15 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(chartComponent)
 
 	sc = ch.NewSubchapter("Headers and footers")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Convenience functions are provided to generate headers and footers, see: " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Convenience functions are provided to generate headers and footers, see: " +
 		"https://godoc.org/github.com/unidoc/unipdf/creator#Creator.DrawHeader and " +
 		"https://godoc.org/github.com/unidoc/unipdf/creator#Creator.DrawFooter " +
 		"They both set a function that accepts a block which the header/footer is drawn on for each page. " +
@@ -486,22 +542,25 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 		"showing page number and count.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
 	sc = ch.NewSubchapter("Table of contents generation")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("A convenience function is provided to generate table of contents " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("A convenience function is provided to generate table of contents " +
 		"as can be seen on https://godoc.org/github.com/unidoc/unipdf/creator#Creator.CreateTableOfContents and " +
 		"in our example code on unidoc.io.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 

--- a/report/pdf_report_from_csv.go
+++ b/report/pdf_report_from_csv.go
@@ -107,24 +107,27 @@ func main() {
 	normalFontColor := creator.ColorRGBFrom8bit(72, 86, 95)
 	normalFontSize := 10.0
 
-	ch.GetHeading().SetFont(chapterFont)
-	ch.GetHeading().SetFontSize(chapterFontSize)
-	ch.GetHeading().SetFontColor(chapterFontColor)
+	heading := ch.GetHeading()
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
 
-	p := c.NewParagraph("Here we provide sales report for the month of January." +
+	p := c.NewStyledParagraph()
+	p.SetText("Here we provide sales report for the month of January." +
 		"The data reflects a diverse range of sales activities, showcasing the efforts of various salespeople. " +
 		"The sales prices ranged from $40 to $250, highlighting the varying value of the products sold." +
 		"Overall, this month demonstrated strong performance across the board," +
 		" indicating effective sales strategies and engagement by the team throughout January.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	ch.Add(p)
 	c.Draw(ch)
 
 	// Create Bar chart
-	p = c.NewParagraph("Total Sales By SalesPerson")
+	p = c.NewStyledParagraph()
+	p.SetText("Total Sales By SalesPerson")
 	p.SetFont(robotoFontRegular)
 	p.SetFontSize(10)
 	p.SetPos(60, 150)
@@ -143,7 +146,8 @@ func main() {
 	}
 
 	// Create pie chart
-	p = c.NewParagraph("Sales Contributions by Sales Persons")
+	p = c.NewStyledParagraph()
+	p.SetText("Sales Contributions by Sales Persons")
 	p.SetFont(robotoFontRegular)
 	p.SetFontSize(10)
 	p.SetPos(370, 150)
@@ -186,19 +190,21 @@ func main() {
 func doFooter(c *creator.Creator, font *model.PdfFont) {
 	c.DrawFooter(func(block *creator.Block, args creator.FooterFunctionArgs) {
 		// Draw the on a block for each page.
-		p := c.NewParagraph("unidoc.io")
+		p := c.NewStyledParagraph()
+		p.SetText("unidoc.io")
 		p.SetFont(font)
 		p.SetFontSize(8)
 		p.SetPos(50, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 
 		strPage := fmt.Sprintf("Page %d of %d", args.PageNum, args.TotalPages)
-		p = c.NewParagraph(strPage)
+		p = c.NewStyledParagraph()
+		p.SetText(strPage)
 		p.SetFont(font)
 		p.SetFontSize(8)
 		p.SetPos(300, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 	})
 }
@@ -208,28 +214,31 @@ func doFirstPage(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model
 	helvetica, _ := model.NewStandard14Font("Helvetica")
 	helveticaBold, _ := model.NewStandard14Font("Helvetica-Bold")
 
-	p := c.NewParagraph("UniDoc")
+	p := c.NewStyledParagraph()
+	p.SetText("UniDoc")
 	p.SetFont(helvetica)
 	p.SetFontSize(48)
 	p.SetMargins(85, 0, 150, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 
-	p = c.NewParagraph("Sample Report From CSV")
+	p = c.NewStyledParagraph()
+	p.SetText("Sample Report From CSV")
 	p.SetFont(helveticaBold)
 	p.SetFontSize(30)
 	p.SetMargins(85, 0, 0, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(45, 148, 215))
+	p.SetFontColor(creator.ColorRGBFrom8bit(45, 148, 215))
 	c.Draw(p)
 
 	t := time.Now().UTC()
 	dateStr := t.Format("1 Jan, 2006 15:04")
 
-	p = c.NewParagraph(dateStr)
+	p = c.NewStyledParagraph()
+	p.SetText(dateStr)
 	p.SetFont(helveticaBold)
 	p.SetFontSize(12)
 	p.SetMargins(90, 0, 5, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 }
 

--- a/report/pdf_report_landscape.go
+++ b/report/pdf_report_landscape.go
@@ -101,19 +101,21 @@ func RunPdfReport(outputPath string) error {
 	// Draw footer on each page.
 	c.DrawFooter(func(block *creator.Block, args creator.FooterFunctionArgs) {
 		// Draw the on a block for each page.
-		p := c.NewParagraph("unidoc.io")
+		p := c.NewStyledParagraph()
+		p.SetText("unidoc.io")
 		p.SetFont(robotoFontRegular)
 		p.SetFontSize(8)
 		p.SetPos(50, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 
 		strPage := fmt.Sprintf("Page %d of %d", args.PageNum, args.TotalPages)
-		p = c.NewParagraph(strPage)
+		p = c.NewStyledParagraph()
+		p.SetText(strPage)
 		p.SetFont(robotoFontRegular)
 		p.SetFontSize(8)
 		p.SetPos(750, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 	})
 
@@ -130,28 +132,31 @@ func DoFirstPage(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model
 	helvetica, _ := model.NewStandard14Font("Helvetica")
 	helveticaBold, _ := model.NewStandard14Font("Helvetica-Bold")
 
-	p := c.NewParagraph("UniDoc")
+	p := c.NewStyledParagraph()
+	p.SetText("UniDoc")
 	p.SetFont(helvetica)
 	p.SetFontSize(48)
 	p.SetMargins(85, 0, 150, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 
-	p = c.NewParagraph("Example Report")
+	p = c.NewStyledParagraph()
+	p.SetText("Example Report")
 	p.SetFont(helveticaBold)
 	p.SetFontSize(30)
 	p.SetMargins(85, 0, 0, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(45, 148, 215))
+	p.SetFontColor(creator.ColorRGBFrom8bit(45, 148, 215))
 	c.Draw(p)
 
 	t := time.Now().UTC()
 	dateStr := t.Format("1 Jan, 2006 15:04")
 
-	p = c.NewParagraph(dateStr)
+	p = c.NewStyledParagraph()
+	p.SetText(dateStr)
 	p.SetFont(helveticaBold)
 	p.SetFontSize(12)
 	p.SetMargins(90, 0, 5, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 }
 
@@ -159,14 +164,18 @@ func DoFirstPage(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model
 func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold *model.PdfFont) {
 	ch := c.NewChapter("Document control")
 	ch.SetMargins(0, 0, 40, 0)
-	ch.GetHeading().SetFont(fontRegular)
-	ch.GetHeading().SetFontSize(18)
-	ch.GetHeading().SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
+
+	heading := ch.GetHeading()
+	heading.SetFont(fontRegular)
+	heading.SetFontSize(18)
+	heading.SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
 
 	sc := ch.NewSubchapter("Issuer details")
-	sc.GetHeading().SetFont(fontRegular)
-	sc.GetHeading().SetFontSize(18)
-	sc.GetHeading().SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
+
+	heading = ch.GetHeading()
+	heading.SetFont(fontRegular)
+	heading.SetFontSize(18)
+	heading.SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
 
 	issuerTable := c.NewTable(2)
 	issuerTable.SetMargins(0, 0, 30, 0)
@@ -174,87 +183,105 @@ func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	pColor := creator.ColorRGBFrom8bit(72, 86, 95)
 	bgColor := creator.ColorRGBFrom8bit(56, 68, 67)
 
-	p := c.NewParagraph("Issuer")
+	p := c.NewStyledParagraph()
+	p.SetText("Issuer")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell := issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("UniDoc")
+	p = c.NewStyledParagraph()
+	p.SetText("UniDoc")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Address")
+	p = c.NewStyledParagraph()
+	p.SetText("Address")
 	p.SetFont(fontBold)
-	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Klapparstig 16, 101 Reykjavik, Iceland")
+	p = c.NewStyledParagraph()
+	p.SetText("Klapparstig 16, 101 Reykjavik, Iceland")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Email")
+	p = c.NewStyledParagraph()
+	p.SetText("Email")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBackgroundColor(bgColor)
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("sales@unidoc.io")
+	p = c.NewStyledParagraph()
+	p.SetText("sales@unidoc.io")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Web")
+	p = c.NewStyledParagraph()
+	p.SetText("Web")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("unidoc.io")
+	p = c.NewStyledParagraph()
+	p.SetText("unidoc.io")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("Author")
+	p = c.NewStyledParagraph()
+	p.SetText("Author")
 	p.SetFont(fontBold)
 	p.SetFontSize(10)
-	p.SetColor(creator.ColorWhite)
+	p.SetFontColor(creator.ColorWhite)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetBackgroundColor(bgColor)
 	cell.SetContent(p)
 
-	p = c.NewParagraph("UniDoc report generator")
+	p = c.NewStyledParagraph()
+	p.SetText("UniDoc report generator")
 	p.SetFont(fontRegular)
 	p.SetFontSize(10)
-	p.SetColor(pColor)
+	p.SetFontColor(pColor)
+
 	cell = issuerTable.NewCell()
 	cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 	cell.SetContent(p)
@@ -264,19 +291,23 @@ func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	// 1.2 - Document history
 	sc = ch.NewSubchapter("Document History")
 	sc.SetMargins(0, 0, 5, 0)
-	sc.GetHeading().SetFont(fontRegular)
-	sc.GetHeading().SetFontSize(18)
-	sc.GetHeading().SetFontColor(pColor)
+
+	heading = sc.GetHeading()
+	heading.SetFont(fontRegular)
+	heading.SetFontSize(18)
+	heading.SetFontColor(pColor)
 
 	histTable := c.NewTable(3)
 	histTable.SetMargins(0, 0, 30, 50)
 
 	histCols := []string{"Date Issued", "UniDoc Version", "Type/Change"}
 	for _, histCol := range histCols {
-		p = c.NewParagraph(histCol)
+		p = c.NewStyledParagraph()
+		p.SetText(histCol)
 		p.SetFont(fontBold)
 		p.SetFontSize(10)
-		p.SetColor(creator.ColorWhite)
+		p.SetFontColor(creator.ColorWhite)
+
 		cell = histTable.NewCell()
 		cell.SetBackgroundColor(bgColor)
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
@@ -289,10 +320,12 @@ func DoDocumentControl(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 
 	histVals := []string{dateStr, common.Version, "First issue"}
 	for _, histVal := range histVals {
-		p = c.NewParagraph(histVal)
+		p = c.NewStyledParagraph()
+		p.SetText(histVal)
 		p.SetFont(fontRegular)
 		p.SetFontSize(10)
-		p.SetColor(pColor)
+		p.SetFontColor(pColor)
+
 		cell = histTable.NewCell()
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 		cell.SetHorizontalAlignment(creator.CellHorizontalAlignmentCenter)
@@ -326,30 +359,35 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 
 	bgColor := creator.ColorRGBFrom8bit(56, 68, 67)
 
-	ch.GetHeading().SetFont(chapterFont)
-	ch.GetHeading().SetFontSize(chapterFontSize)
-	ch.GetHeading().SetFontColor(chapterFontColor)
+	heading := ch.GetHeading()
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
 
-	p := c.NewParagraph("This chapter demonstrates a few of the features of UniDoc that can be used for report generation.")
+	p := c.NewStyledParagraph()
+	p.SetText("This chapter demonstrates a few of the features of UniDoc that can be used for report generation.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	ch.Add(p)
 
 	// Paragraphs.
 	sc := ch.NewSubchapter("Paragraphs")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Paragraphs are used to represent text, as little as a single character, a word or " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Paragraphs are used to represent text, as little as a single character, a word or " +
 		"multiple words forming multiple sentences. UniDoc handles automatically wrapping those across lines and pages, making " +
 		"it relatively easy to work with. They can also be left, center, right aligned or justified as illustrated below:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
@@ -362,10 +400,11 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	alignments := []creator.TextAlignment{creator.TextAlignmentLeft, creator.TextAlignmentCenter,
 		creator.TextAlignmentRight, creator.TextAlignmentJustify}
 	for j := 0; j < 4; j++ {
-		p = c.NewParagraph(loremTxt)
+		p = c.NewStyledParagraph()
+		p.SetText(loremTxt)
 		p.SetFont(normalFont)
 		p.SetFontSize(normalFontSize)
-		p.SetColor(normalFontColor)
+		p.SetFontColor(normalFontColor)
 		p.SetMargins(20, 0, 10, 10)
 		p.SetTextAlignment(alignments[j%4])
 
@@ -379,10 +418,12 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	// Column headers:
 	tableCols := []string{"Priority", "Items fulfilled / available"}
 	for _, tableCol := range tableCols {
-		p = c.NewParagraph(tableCol)
+		p = c.NewStyledParagraph()
+		p.SetText(tableCol)
 		p.SetFont(fontBold)
 		p.SetFontSize(10)
-		p.SetColor(creator.ColorWhite)
+		p.SetFontColor(creator.ColorWhite)
+
 		cell := priTable.NewCell()
 		cell.SetBackgroundColor(bgColor)
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
@@ -395,10 +436,12 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	}
 	for _, lineItems := range items {
 		for _, item := range lineItems {
-			p = c.NewParagraph(item)
+			p = c.NewStyledParagraph()
+			p.SetText(item)
 			p.SetFont(fontBold)
 			p.SetFontSize(10)
-			p.SetColor(creator.ColorWhite)
+			p.SetFontColor(creator.ColorWhite)
+
 			cell := priTable.NewCell()
 			cell.SetBackgroundColor(bgColor)
 			cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
@@ -408,15 +451,18 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(priTable)
 
 	sc = ch.NewSubchapter("Images")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Images can be loaded from multiple file formats, example from a PNG image:")
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Images can be loaded from multiple file formats, example from a PNG image:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 5)
 	sc.Add(p)
 
@@ -429,15 +475,18 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(img)
 
 	sc = ch.NewSubchapter("QR Codes / Barcodes")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Example of a QR code generated with package github.com/boombuler/barcode:")
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Example of a QR code generated with package github.com/boombuler/barcode:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 5)
 	sc.Add(p)
 
@@ -451,16 +500,19 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(img)
 
 	sc = ch.NewSubchapter("Graphing / Charts")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Graphs can be generated via packages such as github.com/unidoc/unichart as illustrated " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Graphs can be generated via packages such as github.com/unidoc/unichart as illustrated " +
 		"in the following plot:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
@@ -478,12 +530,15 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 	sc.Add(chartComponent)
 
 	sc = ch.NewSubchapter("Headers and footers")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Convenience functions are provided to generate headers and footers, see: " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Convenience functions are provided to generate headers and footers, see: " +
 		"https://godoc.org/github.com/unidoc/unipdf/creator#Creator.DrawHeader and " +
 		"https://godoc.org/github.com/unidoc/unipdf/creator#Creator.DrawFooter " +
 		"They both set a function that accepts a block which the header/footer is drawn on for each page. " +
@@ -491,22 +546,25 @@ func DoFeatureOverview(c *creator.Creator, fontRegular *model.PdfFont, fontBold 
 		"showing page number and count.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
 	sc = ch.NewSubchapter("Table of contents generation")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("A convenience function is provided to generate table of contents " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("A convenience function is provided to generate table of contents " +
 		"as can be seen on https://godoc.org/github.com/unidoc/unipdf/creator#Creator.CreateTableOfContents and " +
 		"in our example code on unidoc.io.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 

--- a/svg/pdf_report_with_logo.go
+++ b/svg/pdf_report_with_logo.go
@@ -70,19 +70,21 @@ func generatePDFReport(outputPath string) error {
 	// Draw footer on each page.
 	c.DrawFooter(func(block *creator.Block, args creator.FooterFunctionArgs) {
 		// Draw the on a block for each page.
-		p := c.NewParagraph("unidoc.io")
+		p := c.NewStyledParagraph()
+		p.SetText("unidoc.io")
 		p.SetFont(robotoFontRegular)
 		p.SetFontSize(8)
 		p.SetPos(50, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 
 		strPage := fmt.Sprintf("Page %d of %d", args.PageNum, args.TotalPages)
-		p = c.NewParagraph(strPage)
+		p = c.NewStyledParagraph()
+		p.SetText(strPage)
 		p.SetFont(robotoFontRegular)
 		p.SetFontSize(8)
 		p.SetPos(300, 20)
-		p.SetColor(creator.ColorRGBFrom8bit(63, 68, 76))
+		p.SetFontColor(creator.ColorRGBFrom8bit(63, 68, 76))
 		block.Draw(p)
 	})
 
@@ -99,28 +101,31 @@ func createCoverPage(c *creator.Creator, fontRegular *model.PdfFont, fontBold *m
 	helvetica, _ := model.NewStandard14Font("Helvetica")
 	helveticaBold, _ := model.NewStandard14Font("Helvetica-Bold")
 
-	p := c.NewParagraph("UniDoc")
+	p := c.NewStyledParagraph()
+	p.SetText("UniDoc")
 	p.SetFont(helvetica)
 	p.SetFontSize(48)
 	p.SetMargins(85, 0, 150, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 
-	p = c.NewParagraph("Example Report")
+	p = c.NewStyledParagraph()
+	p.SetText("Example Report")
 	p.SetFont(helveticaBold)
 	p.SetFontSize(30)
 	p.SetMargins(85, 0, 0, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(45, 148, 215))
+	p.SetFontColor(creator.ColorRGBFrom8bit(45, 148, 215))
 	c.Draw(p)
 
 	t := time.Now().UTC()
 	dateStr := t.Format("01 Jan, 2006 15:04")
 
-	p = c.NewParagraph(dateStr)
+	p = c.NewStyledParagraph()
+	p.SetText(dateStr)
 	p.SetFont(helveticaBold)
 	p.SetFontSize(12)
 	p.SetMargins(90, 0, 5, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 }
 
@@ -139,63 +144,71 @@ func doFirstHeader(c *creator.Creator, fontRegular *model.PdfFont, fontBold *mod
 	normalFontColor := creator.ColorRGBFrom8bit(72, 86, 95)
 	normalFontSize := 10.0
 
-	ch.GetHeading().SetFont(chapterFont)
-	ch.GetHeading().SetFontSize(chapterFontSize)
-	ch.GetHeading().SetFontColor(chapterFontColor)
+	heading := ch.GetHeading()
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
 
-	p := c.NewParagraph("This is an example sentence showcasing the content of the first header. It provides a brief introduction to the section, highlighting the key points that will be discussed under the header.")
+	p := c.NewStyledParagraph()
+	p.SetText("This is an example sentence showcasing the content of the first header. It provides a brief introduction to the section, highlighting the key points that will be discussed under the header.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	ch.Add(p)
 
 	// Paragraphs.
 	sc := ch.NewSubchapter("Sub Header")
-	sc.GetHeading().SetMargins(0, 0, 20, 0)
-	sc.GetHeading().SetFont(chapterFont)
-	sc.GetHeading().SetFontSize(chapterFontSize)
-	sc.GetHeading().SetFontColor(chapterFontColor)
 
-	p = c.NewParagraph("Paragraphs are used to represent text, as little as a single character, a word or " +
+	heading = sc.GetHeading()
+	heading.SetMargins(0, 0, 20, 0)
+	heading.SetFont(chapterFont)
+	heading.SetFontSize(chapterFontSize)
+	heading.SetFontColor(chapterFontColor)
+
+	p = c.NewStyledParagraph()
+	p.SetText("Paragraphs are used to represent text, as little as a single character, a word or " +
 		"multiple words forming multiple sentences. UniDoc handles automatically wrapping those across lines and pages, making " +
 		"it relatively easy to work with. They can also be left, center, right aligned or justified as illustrated below:")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
 	// Example paragraphs:
-	p = c.NewParagraph("This paragraph shows the first paragraph of the subheader. It introduces the topic that will be " +
+	p = c.NewStyledParagraph()
+	p.SetText("This paragraph shows the first paragraph of the subheader. It introduces the topic that will be " +
 		"discussed in the subsequent sections. The purpose of this introduction is to set the context for " +
 		"the reader. By doing so, it ensures a smooth transition into the more detailed points. The reader " +
 		"can expect an overview of the important aspects related to the subheader.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
-	p = c.NewParagraph("This paragraph demonstrates the second paragraph of the subheader. It delves deeper into the " +
+	p = c.NewStyledParagraph()
+	p.SetText("This paragraph demonstrates the second paragraph of the subheader. It delves deeper into the " +
 		"specific details of the topic introduced earlier. Here, more focus is given to explaining key " +
 		"concepts or arguments that are central to the subject. The paragraph aims to elaborate on " +
 		"important points while keeping the reader engaged. By offering clear explanations, it supports the " +
 		"overall understanding of the subject matter.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 
-	p = c.NewParagraph("This is the third paragraph of the subheader. It provides a conclusion or a summary of the key " +
+	p = c.NewStyledParagraph()
+	p.SetText("This is the third paragraph of the subheader. It provides a conclusion or a summary of the key " +
 		"takeaways discussed in the previous paragraphs. This section often reinforces the main message " +
 		"or insights of the topic. By wrapping up the discussion, it offers closure and emphasizes the most " +
 		"important points. The paragraph also paves the way for the reader to reflect on the subject and " +
 		"prepare for what might come next.")
 	p.SetFont(normalFont)
 	p.SetFontSize(normalFontSize)
-	p.SetColor(normalFontColor)
+	p.SetFontColor(normalFontColor)
 	p.SetMargins(0, 0, 5, 0)
 	sc.Add(p)
 

--- a/tables/pdf_tables_row_wrap.go
+++ b/tables/pdf_tables_row_wrap.go
@@ -71,15 +71,17 @@ func rowWrapDisabled(c *creator.Creator, headingFont *model.PdfFont) error {
 
 	return fillTable(c, 22, false, func(table *creator.Table) error {
 		sp1 := c.NewStyledParagraph()
-		sp1.Append("This is a styled paragraph which will not fit on the current page. All its content should be moved on the next page, along with the entire row, as row wrapping is disabled.").Style.FontSize = 14
+		sp1.SetText("This is a styled paragraph which will not fit on the current page. All its content should be moved on the next page, along with the entire row, as row wrapping is disabled.").Style.FontSize = 14
 
-		p1 := c.NewParagraph("This is a regular paragraph which will fit on the current page. However, it will be moved on the next page.")
+		p1 := c.NewStyledParagraph()
+		p1.SetText("This is a regular paragraph which will fit on the current page. However, it will be moved on the next page.")
 		p1.SetFontSize(14)
 
 		sp2 := c.NewStyledParagraph()
-		sp2.Append("This is a styled paragraph which will fit on the current page. However, it will be moved on the next page.").Style.FontSize = 14
+		sp2.SetText("This is a styled paragraph which will fit on the current page. However, it will be moved on the next page.").Style.FontSize = 14
 
-		p2 := c.NewParagraph("This is a regular paragraph which will not fit on the current page. All its content should be moved on the next page, along with the entire row.")
+		p2 := c.NewStyledParagraph()
+		p2.SetText("This is a regular paragraph which will not fit on the current page. All its content should be moved on the next page, along with the entire row.")
 		p2.SetFontSize(14)
 
 		// Draw table row.
@@ -119,15 +121,17 @@ func rowWrapEnabled(c *creator.Creator, headingFont *model.PdfFont) error {
 
 	return fillTable(c, 22, true, func(table *creator.Table) error {
 		sp1 := c.NewStyledParagraph()
-		sp1.Append("This is a styled paragraph. When table row wrapping is enabled, the content that fits on the current page stays on the current page. The rest of the content will be placed on the next page.").Style.FontSize = 14
+		sp1.SetText("This is a styled paragraph. When table row wrapping is enabled, the content that fits on the current page stays on the current page. The rest of the content will be placed on the next page.").Style.FontSize = 14
 
-		p1 := c.NewParagraph("This is a regular paragraph which will fit on the current page. All its content should remain on the current page.")
+		p1 := c.NewStyledParagraph()
+		p1.SetText("This is a regular paragraph which will fit on the current page. All its content should remain on the current page.")
 		p1.SetFontSize(14)
 
 		sp2 := c.NewStyledParagraph()
-		sp2.Append("This is a styled paragraph which will fit on the current page. All its content should remain on the current page.").Style.FontSize = 14
+		sp2.SetText("This is a styled paragraph which will fit on the current page. All its content should remain on the current page.").Style.FontSize = 14
 
-		p2 := c.NewParagraph("This is a regular paragraph which will not fit on the current page. All its content should be moved on the next page, in the wrapped row, leaving the current cell empty.")
+		p2 := c.NewStyledParagraph()
+		p2.SetText("This is a regular paragraph which will not fit on the current page. All its content should be moved on the next page, in the wrapped row, leaving the current cell empty.")
 		p2.SetFontSize(14)
 
 		// Draw table row.

--- a/tables/pdf_tables_rowspan.go
+++ b/tables/pdf_tables_rowspan.go
@@ -57,9 +57,11 @@ func rowSpan(c *creator.Creator, font, fontBold *model.PdfFont) error {
 	// Create subchapter.
 	ch := c.NewChapter("Row span")
 	ch.SetMargins(0, 0, 30, 0)
-	ch.GetHeading().SetFont(font)
-	ch.GetHeading().SetFontSize(13)
-	ch.GetHeading().SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
+
+	heading := ch.GetHeading()
+	heading.SetFont(font)
+	heading.SetFontSize(13)
+	heading.SetFontColor(creator.ColorRGBFrom8bit(72, 86, 95))
 
 	// Create subchapter description.
 	desc := c.NewStyledParagraph()
@@ -81,9 +83,12 @@ func rowSpan(c *creator.Creator, font, fontBold *model.PdfFont) error {
 			cell = table.MultiRowCell(rowspan)
 		}
 
+		p := c.NewStyledParagraph()
+		p.SetText(fmt.Sprintf("%d - %d", table.CurRow(), table.CurCol()))
+
 		cell.SetBorder(creator.CellBorderSideAll, creator.CellBorderStyleSingle, 1)
 		cell.SetBackgroundColor(bgColor)
-		cell.SetContent(c.NewParagraph(fmt.Sprintf("%d - %d", table.CurRow(), table.CurCol())))
+		cell.SetContent(p)
 		cell.SetHorizontalAlignment(creator.CellHorizontalAlignmentCenter)
 		cell.SetIndent(0)
 	}

--- a/text/pdf_insert_text.go
+++ b/text/pdf_insert_text.go
@@ -98,7 +98,8 @@ func addTextToPdf(inputPath string, outputPath string, text string, pageNum int,
 		}
 
 		if i == pageNum || pageNum == -1 {
-			p := c.NewParagraph(text)
+			p := c.NewStyledParagraph()
+			p.SetText(text)
 			// Change to times bold font (default is helvetica).
 			timesBold, err := model.NewStandard14Font("Times-Bold")
 			if err != nil {

--- a/text/pdf_using_unicode_font.go
+++ b/text/pdf_using_unicode_font.go
@@ -61,25 +61,28 @@ func genPdfFile(outputFile string) error {
 }
 
 func writeContent(c *creator.Creator, compositeFont *model.PdfFont) {
-	p := c.NewParagraph("こんにちは世界")
+	p := c.NewStyledParagraph()
+	p.SetText("こんにちは世界")
 	p.SetFont(compositeFont)
 	p.SetFontSize(48)
 	p.SetMargins(85, 0, 150, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 
-	p = c.NewParagraph("UniPDFへようこそ")
+	p = c.NewStyledParagraph()
+	p.SetText("UniPDFへようこそ")
 	p.SetFont(compositeFont)
 	p.SetFontSize(48)
 	p.SetMargins(85, 0, 0, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 
-	p = c.NewParagraph("Welcome To UniPDF")
+	p = c.NewStyledParagraph()
+	p.SetText("Welcome To UniPDF")
 	p.SetFont(compositeFont)
 	p.SetFontSize(30)
 	p.SetMargins(85, 0, 0, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(45, 148, 215))
+	p.SetFontColor(creator.ColorRGBFrom8bit(45, 148, 215))
 	c.Draw(p)
 }
 
@@ -99,10 +102,11 @@ func addCurrencyPage(c *creator.Creator, compositeFont *model.PdfFont) {
 		"\u5143 (TWD - New Taiwan Dollar)\n" +
 		"\u20ab (VND - Dong)\n"
 
-	p := c.NewParagraph(currencyText)
+	p := c.NewStyledParagraph()
+	p.SetText(currencyText)
 	p.SetFont(compositeFont)
 	p.SetFontSize(20)
 	p.SetMargins(85, 0, 150, 0)
-	p.SetColor(creator.ColorRGBFrom8bit(56, 68, 77))
+	p.SetFontColor(creator.ColorRGBFrom8bit(56, 68, 77))
 	c.Draw(p)
 }


### PR DESCRIPTION
Since we're deprecating `Paragraph` component in favor of `StyledParagraph`, this PR objective is to replace any reference to `Paragraph` component with `StyledParagraph`.